### PR TITLE
Added shebang to explicitly run bin with node

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,3 +1,5 @@
+#!/usr/bin/env node
+
 import fs from 'fs/promises';
 import _glob from 'glob';
 import meow from 'meow';


### PR DESCRIPTION
On Windows the CLI fails as it is executed with Windows Script Host instead of node. This happens because cli.js is missing the shebang. This change allows the CLI to function on Windows.

From [npm's docs](https://docs.npmjs.com/cli/v6/configuring-npm/package-json#bin):

> Please make sure that your file(s) referenced in bin starts with #!/usr/bin/env node, otherwise the scripts are started without the node executable!